### PR TITLE
Refact: Zustand 의존성 줄이기 외

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ function App() {
         <Route path='/end' element={<End />} />
       </Routes>
       <section className="background">
-        <img src={background} />
+        <img alt='배경이미지' src={background} />
       </section>
     </div>
   )

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -14,11 +14,11 @@ const Card = forwardRef<HTMLDivElement>((_, ref) => {
     return (
         <div className={style.container} ref={ref}>
             <section className={style.title}>
-                <img  src={title3} />
+                <img src={title3} alt='타이틀 이미지'  />
             </section>
             <section className={style.innerContainer}>
                 <div className={style.score}>{score}<span>점!</span></div>
-                <img src={cardImg} />
+                <img src={cardImg} alt='깃발을 펄럭이는 캐릭터 이미지' />
             </section>
         </div>
     )

--- a/src/components/Character.tsx
+++ b/src/components/Character.tsx
@@ -18,15 +18,18 @@ const Character = () => {
           <div className={style.userName}>{userName}</div>
           <img className={style.head} 
             src={headImg}
+            alt='캐릭터 머리' 
             />
           <img key={`left_${left}`} className={`${left === "down" ? style.left : style.leftUp}`} 
             src={left==="down" ? leftDownImg : leftUpImg} 
+            alt='캐릭터 왼팔' 
           />
           <img key={`right_${right}`} className={`${right === "down" ? style.right : style.rightUp}`}  
             src={right==="down" ? rightDownImg : rightUpImg}
+            alt='캐릭터 오른팔' 
           />
       </section>
-      <img className={style.legs} src={legImg} />
+      <img className={style.legs} src={legImg} alt='캐릭터 다리' />
     </div>
   )
 }

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -22,7 +22,7 @@ const Modal = ({ text, image, buttonText, onClick }: IModal) => {
                 <div>
                     <div className={style.Modal}>
                         <div className={style.text}>{text}</div>
-                        {image && <img src={image} className={style.image} />}
+                        {image && <img src={image} className={style.image} alt={`${text},라는 안내와 관련된 이미지`} />}
                         {buttonText && (
                             <Button
                                 onClick={onClickButton}

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -14,16 +14,16 @@ function Game() {
 
   const left = boundStore.use.left();
   const right = boundStore.use.right();
-  const score = boundStore.use.score();
-  const life = boundStore.use.life();
-
-  const loseLife = boundStore.use.loseLife();
+  const score = boundStore.use.score();  
   const addScore = boundStore.use.addScore();
-  const setContinue = boundStore.use.setContinue();
-
+  
+  const initialRenderRef = useRef<boolean>(true);
   const prevStateRef = useRef<IState|null>(null);
   const currentCommandRef = useRef<IGameCommand|null>(null);
-  const initialRenderRef = useRef<boolean>(true);
+  
+  const [life, loseLife] = useState<number>(3);
+  const continueGameRef = useRef<boolean>(true);
+
   const [judged, setJudged] = useState<"yet"|"pass"|"fail">("yet");
 
   const playAudio = (sounds: string[]) => {
@@ -61,13 +61,13 @@ function Game() {
   };
 
   const handleFail = () => {
-    const { life: currentLife } = boundStore.getState();
-        if (currentLife > 0)
-          loseLife();
-        else if (currentLife === 0) {
-          setTimeout(() => nav("/end", { replace: true }), 3000);
-          setContinue(false);
-        }
+
+      if (life > 0)
+        loseLife((prev) => prev - 1);
+      else if (life === 0) {
+        setTimeout(() => nav("/end", { replace: true }), 3000);
+        continueGameRef.current = false;
+      }
   }
 
   const gameStart = async () => {
@@ -87,8 +87,7 @@ function Game() {
       }
 
       setTimeout(() => {
-        const { continueGame } = boundStore.getState();
-      if (continueGame) {
+      if (continueGameRef.current) {
         setJudged("yet");
         gameStart();
       }
@@ -99,7 +98,7 @@ function Game() {
     gameStart();
 
     return () => {
-      setContinue(false);
+      continueGameRef.current = false;
     }
   }, []);
 

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -126,9 +126,9 @@ function Game() {
         headChild={<section className={style.score}>{score}</section>}
         footChild={
           <section className={style.life}>
-            <img className={style.heart} src={life >= 1 ? heart3 : ""} />
-            <img className={style.heart} src={life >= 2 ? heart2 : ""} />
-            <img className={style.heart} src={life >= 3 ? heart3 : ""} />
+            <img className={style.heart} src={life >= 1 ? heart3 : ""} alt="첫번째 생명" />
+            <img className={style.heart} src={life >= 2 ? heart2 : ""} alt="두번째 생명" />
+            <img className={style.heart} src={life >= 3 ? heart3 : ""} alt="세번째 생명" />
           </section>
         }
       />

--- a/src/pages/Start.tsx
+++ b/src/pages/Start.tsx
@@ -58,13 +58,13 @@ function Start() {
       <Layout 
         headChild={
           <section className={style.title}> 
-            <img src={title} />
+            <img src={title} alt='게임 타이틀' />
           </section>
         }
         footChild={(
           <section className={style.startButton} onClick={startGame}>
             <div className={style.buttonText}>게임 시작!</div>
-            <img src={button2}/>
+            <img src={button2} alt='말풍선. 게임 시작 버튼으로 사용' />
           </section>
         )}
         onClick={()=>{console.log("마이 보디!!!")}}

--- a/src/stores/gameSlice.store.ts
+++ b/src/stores/gameSlice.store.ts
@@ -4,19 +4,11 @@ import { ISlice } from "./boundStore.store";
 export interface IGameSlice {
   score: number;
   addScore: () => void;
-  life: number;
-  loseLife: () => void;
-  continueGame: boolean;
-  setContinue: (continueGame: boolean) => void;
   setInitializeGame: () => void;
 }
 
 export const gameSlice: StateCreator<ISlice, [], [], IGameSlice> = (set) => ({
   score: 0,
   addScore: () => set((state) => ({ score: state.score + 1 })),
-  life: 3,
-  loseLife: () => set((state) => ({ life: state.life - 1 })),
-  continueGame: true,
-  setContinue: (continueGame) => set(() => ({ continueGame })),
-  setInitializeGame: () => set(() => ({ score: 0, life: 3 })),
+  setInitializeGame: () => set(() => ({ score: 0})),
 })


### PR DESCRIPTION
- 게임 페이지의 `life`상태와 `continueGame` 상태를 전역 스토어가 아닌 페이지 컴포넌트 내에서 관리하도록 수정. Zustand의 의존성을 줄임
- SEO 지수 향상을 위해 이미지 요소에 alt 프로퍼티 추가 기입