### PR TITLE
Fix: Zustand 스토어에서 삭제된 상태 내용 반영 누락 수정 외

### DIFF
--- a/src/hooks/useStartGame.ts
+++ b/src/hooks/useStartGame.ts
@@ -5,13 +5,11 @@ const useStartGame = () => {
   const nav = useNavigate();
   const setInitializeGame = boundStore.use.setInitializeGame();
   const setInitializeMotion = boundStore.use.setInitializeMotion();
-  const setContinue = boundStore.use.setContinue();
 
   const startGame = () => {
     nav("/game");
     setInitializeGame();
     setInitializeMotion();
-    setContinue(true);
   }
 
   return startGame;

--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -126,9 +126,9 @@ function Game() {
         headChild={<section className={style.score}>{score}</section>}
         footChild={
           <section className={style.life}>
-            <img className={style.heart} src={life >= 1 ? heart3 : ""} alt="첫번째 생명" />
-            <img className={style.heart} src={life >= 2 ? heart2 : ""} alt="두번째 생명" />
-            <img className={style.heart} src={life >= 3 ? heart3 : ""} alt="세번째 생명" />
+            <img className={style.heart} src={life >= 1 ? heart3 : ""} alt='' />
+            <img className={style.heart} src={life >= 2 ? heart2 : ""} alt='' />
+            <img className={style.heart} src={life >= 3 ? heart3 : ""} alt='' />
           </section>
         }
       />

--- a/src/utils/game.util.ts
+++ b/src/utils/game.util.ts
@@ -10,24 +10,21 @@ export interface IGameCommand {
   sounds: string[];
 }
 
-export const getGameCommand = (): IGameCommand => {
+export const getGameCommand = (): IGameCommand => { // left : right: both = 2 : 2 : 1
   const getSide = (): TSide => {
     const randomNumber = getRandomNumber(0, 4);
 
-    switch (randomNumber) {
-      case 0: return "left";
-      case 1: return "right";
-      case 2: return "left";
-      case 3: return "right";
-      case 4: return "both";
-      default: return "both";
-    }
+    if (randomNumber === 4) return "both";
+    else if (randomNumber % 2 === 0) return "left";
+    else if (randomNumber % 2 === 1) return "right";
   }
 
-  const getCommand = (): ICommand => {
-    const randomNumber = getRandomNumber(0, commands.length - 1);
+  const getCommand = (): ICommand => { // up : down : stay = 3 : 3 : 1
+    const randomNumber = getRandomNumber(0, 6);
 
-    return commands[randomNumber];
+    if (randomNumber === 6) return commands[2];
+    else if (randomNumber % 2 === 0) return commands[0];
+    else if (randomNumber % 2 === 1) return commands[1];
   }
 
   const getScriptString = (side: TSide, command: ICommand, selectedFlag: ISelectedFlag): string => {


### PR DESCRIPTION
- 커스텀 훅 useStartGame에, Zustand 스토어에서 `setContinue`를 삭제되었던 내용에 대한 반영을 누락하여 이를 수정함. 
- 생명 깎인 후 `life` 이미지 빈 공간에 alt 내용이 출력되어 이를 빈 문자열로 수정
- 게임 스크립트에서 '그대로' 나오는 확률 수정