### PR TITLE
Feat: 모바일/PC 환경에 따라 다른 컨트롤 방법 안내를 해주는 컴포넌트 작성

### DIFF
--- a/src/components/ControlInfo.module.css
+++ b/src/components/ControlInfo.module.css
@@ -1,0 +1,71 @@
+.ControlInfo {
+    position: fixed;
+    top: 30vh;
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    gap: 20vh;
+    color: rgba(0, 0, 0, 0.7);
+}
+
+.mobile {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    animation: mobileInfo 1s ease-in-out infinite;
+    color: rgba(0, 0, 0, 0.7);
+}
+
+.mobile svg {
+    width: 8vh;
+    height: 8vh;
+}
+
+@keyframes mobileInfo {
+    0%, 15%, 30%, 45%, 60%, 80%, 100% {
+        transform: translateY(0%);
+        color: rgba(0, 0, 0, 0.7);
+    }
+    20%, 25%, 50%, 55% {
+        transform: translateY(2%);
+        color: rgba(0, 0, 0, 0.7);
+    }
+    85%, 90% {
+        transform: translateY(0%);
+        color: rgba(0, 0, 0, 0.5);
+    }
+}
+
+.pc {
+    position: relative;
+}
+
+.pc .text {
+    background-color: rgb(247, 247, 243);
+    padding: 8px 14px;
+    border-radius: 4px;
+    color: rgba(0, 0, 0, 0.5);
+    animation: pcInfo 1s ease-in-out infinite;
+}
+
+.pc .keyShadow {
+    position: absolute;
+    z-index: -1;
+    top: 4px;
+    left: 4px;
+    background-color: rgba(200, 200, 200);
+    padding: 8px 14px;
+    border-radius: 4px;
+    color: rgba(0, 0, 0, 0);
+}
+
+@keyframes pcInfo {
+    0%, 20%, 27%, 45%, 52%, 100% {
+        transform: translate(0);
+    }
+    22%, 25%, 47%, 50% {
+        transform: translate(1px, 1px);
+    }
+}

--- a/src/components/ControlInfo.tsx
+++ b/src/components/ControlInfo.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+import boundStore from "../stores/boundStore.store"
+import style from "./ControlInfo.module.css";
+import getIsMobile from "../utils/isMobile.util";
+import { TbCircleDotted } from "react-icons/tb";
+
+const ControlInfo = () => {
+    const left = boundStore.use.left();
+    const right = boundStore.use.right();
+    const [controlInfoSign, setControlInfoSign] = useState<"mobile"|"pc"|null>(null);
+
+    useEffect(() => {
+        if (controlInfoSign) 
+            setControlInfoSign(null);
+    }, [left, right])
+
+    useEffect(() => {
+        const isMobile = getIsMobile();
+        if (isMobile) setControlInfoSign("mobile");
+        else setControlInfoSign("pc");
+    }, [])
+
+    if (controlInfoSign==="mobile")
+        return (
+        <div className={style.ControlInfo}>
+                <section className={style.mobile}>
+                    <div className={style.text}>Touch</div>
+                    <TbCircleDotted />
+                </section>
+                <section className={style.mobile}>
+                    <div className={style.text}>Touch</div>
+                    <TbCircleDotted />
+                </section>
+        </div>
+        )
+
+    else if (controlInfoSign==="pc") 
+        return (
+            <div className={style.ControlInfo}>
+                    <section className={style.pc}>
+                        <div className={style.text}>d</div>
+                        <div className={style.keyShadow}>d</div>
+                    </section>
+                    <section className={style.pc}>
+                        <div className={style.text}>k</div>
+                        <div className={style.keyShadow}>d</div>
+                    </section>
+            </div>
+        )
+
+    else return null;
+}
+
+export default ControlInfo;

--- a/src/pages/Start.tsx
+++ b/src/pages/Start.tsx
@@ -7,6 +7,7 @@ import useStartGame from "../hooks/useStartGame";
 import {Howl} from "howler";
 import openingSound from "./../assets/sounds/opening.mp3";
 import { lazy, Suspense, useEffect, useState } from "react";
+import ControlInfo from "../components/ControlInfo";
 
 const Modal = lazy(() => (import("./../components/Modal")));
 
@@ -55,6 +56,7 @@ function Start() {
           </Suspense>
         )
       }
+      <ControlInfo />
       <Layout 
         headChild={
           <section className={style.title}> 

--- a/src/utils/isMobile.util.ts
+++ b/src/utils/isMobile.util.ts
@@ -1,0 +1,6 @@
+const getIsMobile = () => {
+    const userAgent = navigator.userAgent.toLowerCase();
+    return /mobile|android|iphone|ipad|ipod/.test(userAgent);
+  }
+
+export default getIsMobile;


### PR DESCRIPTION
<img width="265" alt="KakaoTalk_20241126_170516247" src="https://github.com/user-attachments/assets/8b47da59-3616-4978-bee6-4c76df29c355">
<img width="265" alt="KakaoTalk_20241126_170608484" src="https://github.com/user-attachments/assets/4340f844-7f4f-4532-8575-828e2672bf95">

(좌) 모바일 버전
(우) PC 버전

- 모바일/PC은 navigator.userAgent로 구분(util\isMobile)
- 첫 컨트롤 감지되면 unvisible